### PR TITLE
Add catalog access method

### DIFF
--- a/.github/workflows/data_availability.yml
+++ b/.github/workflows/data_availability.yml
@@ -20,4 +20,4 @@ jobs:
           enable-cache: true
 
       - name: Check data availability
-        run: uv run --with intake,intake-xarray,jinja2,zarr,s3fs --no-project python tests/check_data_availability.py
+        run: uv run python tests/check_data_availability.py

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -24,12 +24,12 @@ jobs:
                     python-version: '3.10'
 
             - name: Install dependencies
-              run: |
-                    python -m pip install --upgrade pip
-                    pip install jupyter-book ghp-import
+              uses: astral-sh/setup-uv@v2
+              with:
+                    enable-cache: true
 
             - name: Build Jupyter Book
-              run: jupyter-book build danra-book/
+              run: uv run jupyter-book build danra-book/
 
             - name: Upload Jupyter Book as artifact (for debugging)
               uses: actions/upload-artifact@v4
@@ -40,4 +40,4 @@ jobs:
             - name: Deploy to GitHub Pages
               if: startsWith(github.ref, 'refs/tags/')
               run: |
-                    ghp-import -n -p -f danra-book/_build/html
+                    uv run ghp-import -n -p -f danra-book/_build/html

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -31,6 +31,12 @@ jobs:
             - name: Build Jupyter Book
               run: jupyter-book build danra-book/
 
+            - name: Upload Jupyter Book as artifact (for debugging)
+              uses: actions/upload-artifact@v4
+              with:
+                    name: jupyter-book
+                    path: danra-book/_build/html
+
             - name: Deploy to GitHub Pages
               if: startsWith(github.ref, 'refs/tags/')
               run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Add documentation on how to access DANRA output via intake catalog ([#16](https://github.com/dmidk/danradocs/pull/16) @observingClouds)
+- Add links to preprint and documentation as badges in README.md ([#16](https://github.com/dmidk/danradocs/pull/16) @observingClouds)
+
+### Changed
+- Update project dependencies to be able to execute jupyter book and tests ([#16](https://github.com/dmidk/danradocs/pull/16) @observingClouds)
+
 ## [v0.2.2] - 2025-10-08
 ### Added
 - Add zenodo metadata for easier integration with zenodo ([#13](https://github.com/dmidk/danradocs/pull/13) @observingClouds)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # danra-book
 
-This is a jupyter book for the DANRA (Danish Reanalysis) project and dataset.
+This is the jupyter book for the DANRA (Danish Reanalysis) project and dataset.
 
 ## Overview
 
@@ -13,7 +13,7 @@ This Jupyter book serves as an interactive guide and documentation for the DANRA
 
 ## Getting Started
 
-To get started with the DANRA book, you can clone the repository and install the required dependencies.
+To get started with the DANRA book, either visit the documentation at https://dmidk.github.io/danradocs/ or clone the repository and install the required dependencies to run the notebooks locally.
 We recommend using PDM to create a virtual environment to manage the dependencies.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17294180.svg)](https://doi.org/10.5281/zenodo.17294180)
+[![Preprint](https://img.shields.io/badge/preprint-darkred?logo=arxiv)](https://doi.org/10.48550/arXiv.2510.04681)
+[![Documentation](https://img.shields.io/badge/docs-jupyter_book-blue?logo=jupyter)](https://dmidk.github.io/danradocs/)
+[![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
+
 # danra-book
 
 This is a jupyter book for the DANRA (Danish Reanalysis) project and dataset.

--- a/danra-book/_config.yml
+++ b/danra-book/_config.yml
@@ -9,7 +9,8 @@ copyright: '2025'
 # Force re-execution of notebooks on each build.
 # See https://jupyterbook.org/content/execute.html
 execute:
-  execute_notebooks: 'off'
+  exclude_patterns:
+    - 'notebooks/**.ipynb'  # exclude all notebooks in the notebooks folder
 
 # Define the name of the latex output file for PDF builds
 latex:

--- a/danra-book/docs/data-availability.md
+++ b/danra-book/docs/data-availability.md
@@ -27,7 +27,7 @@ list(cat)
 Individual datasets can be loaded with xarray via the catalog:
 
 ```{code-cell} ipython3
-ds_danra_sl = cat.danra_single_levels.to_dask()
+ds_danra_sl = cat.single_levels.to_dask()
 ds_danra_sl
 ```
 

--- a/danra-book/docs/data-availability.md
+++ b/danra-book/docs/data-availability.md
@@ -1,13 +1,45 @@
-# Data Availability
-DANRA reanalysis consists of gridded data for a large number of weather and climate variables, both at 3-hourly analysis time. Some of the parameters are defined on height or pressure levels, the rest are on a single level.
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.12
+    jupytext_version: 1.17.3
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+execution:
+  timeout: 120
+---
 
-The DANRA reanalysis data, available at three-hour intervals at 00:00, 03:00, 06:00, ..., and 21:00 UTC daily (analysis data), can be accessed from an Amazon S3 object store. The data is split into three different Zarr datasets:
+# Data Availability
+DANRA reanalysis consists of gridded data for a large number of weather and climate variables at 3-hourly analysis time (00:00, 03:00, 06:00, ..., and 21:00 UTC). Some of the parameters are defined on height or pressure levels, the rest are on a single level.
+
+The datasets can be accessed via an [Intake catalog](https://intake.readthedocs.io/en/latest/catalog.html) published at [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17294180.svg)](https://doi.org/10.5281/zenodo.17294180)
+
+```{code-cell} ipython3
+import intake
+cat = intake.open_catalog("zip://dmidk-danradocs-a856614/catalog/catalog.yaml::https://zenodo.org/records/17294180/files/dmidk/danradocs-v0.2.2.zip", driver="yaml_file_cat")
+list(cat)
+```
+
+Individual datasets can be loaded with xarray via the catalog:
+
+```{code-cell} ipython3
+ds_danra_sl = cat.danra_single_levels.to_dask()
+ds_danra_sl
+```
+
+Alternatively, the data can be accessed directly from the S3 object store:
+
 - [s3://dmi-danra-05/height_levels.zarr](s3://dmi-danra-05/height_levels.zarr)
 - [s3://dmi-danra-05/single_levels.zarr](s3://dmi-danra-05/single_levels.zarr)
 - [s3://dmi-danra-05/pressure_levels.zarr](s3://dmi-danra-05/pressure_levels.zarr)
 
 Fetching one of these datasets with Python and xarray using simple loading is as simple as
 ```
+import xarray
 ds_danra_sl = xarray.open_zarr(
     "s3://dmi-danra-05/single_levels.zarr",
     consolidated=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
 dependencies = [
     "jupyter-book>=1.0.0",
     "xarray>=2024.5.0",
-    "eccodes>=1.7.0",
     "dask>=2024.5.2",
     "gcsfs>=2024.6.0",
     "intake-xarray>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "dask>=2024.5.2",
     "gcsfs>=2024.6.0",
     "intake-xarray>=2.0.0",
+    "ghp-import>=2.1.0",
 ]
 requires-python = ">=3.12"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "eccodes>=1.7.0",
     "dask>=2024.5.2",
     "gcsfs>=2024.6.0",
+    "intake-xarray>=2.0.0",
 ]
 requires-python = ">=3.12"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "gcsfs>=2024.6.0",
     "intake-xarray>=2.0.0",
     "ghp-import>=2.1.0",
+    "s3fs>=2025.9.0",
+    "jinja2>=3.1.6",
+    "zarr>=3.1.3",
 ]
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
- Adds documentation on how to access the DANRA output via intake catalog
- Adds links to preprint, archived version and website as badges to README
- Switches book build and availability tests to project's dependencies